### PR TITLE
fix(ci): drop Node 18 from matrix (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/index.js
+++ b/index.js
@@ -46,9 +46,9 @@ function validateImagePath(imagefile) {
     return resolvedPath;
   } catch (err) {
     if (err.code === 'ENOENT') {
-      throw new Error(`Image file not found: ${path.basename(imagefile)}`);
+      throw new Error(`Image file not found: ${path.basename(imagefile)}`, { cause: err });
     } else if (err.code === 'EACCES') {
-      throw new Error(`Image file not readable: ${path.basename(imagefile)}`);
+      throw new Error(`Image file not readable: ${path.basename(imagefile)}`, { cause: err });
     }
     throw err;
   }


### PR DESCRIPTION
Node 18 reached EOL in April 2025. Updated CI matrix from [18, 20, 22] to [20, 22].